### PR TITLE
patch for error in openNEV (line 550)

### DIFF
--- a/NPMK/openNEV.m
+++ b/NPMK/openNEV.m
@@ -547,7 +547,9 @@ for ii=1:Trackers.countExtHeader
             return;
     end
 end
-NEV.MetaTags.ChannelID = [NEV.ElectrodesInfo.ElectrodeID];
+if ~isempty(NEV.ElectrodesInfo)
+    NEV.MetaTags.ChannelID = [NEV.ElectrodesInfo.ElectrodeID];
+end
 clear ExtendedHeader PacketID ii;
 
 %% Recording after ExtendedHeader file position and calculating Data Length


### PR DESCRIPTION
I got the following error while attempting to open a .nev file

```
Attempt to reference field of non-structure array.

Error in openNEV (line 550)
NEV.MetaTags.ChannelID = [NEV.ElectrodesInfo.ElectrodeID];
```
