### PR TITLE
Fixes problem when only one electrode is present

### DIFF
--- a/NPMK/openNEV.m
+++ b/NPMK/openNEV.m
@@ -547,7 +547,9 @@ for ii=1:Trackers.countExtHeader
             return;
     end
 end
-NEV.MetaTags.ChannelID = [NEV.ElectrodesInfo.ElectrodeID];
+if isfield(NEV.ElectrodesInfo, 'ElectrodeID')
+    NEV.MetaTags.ChannelID = [NEV.ElectrodesInfo.ElectrodeID];
+end
 clear ExtendedHeader PacketID ii;
 
 %% Recording after ExtendedHeader file position and calculating Data Length


### PR DESCRIPTION
...which seems to lead to an empty .ElectrodesInfo field (at least when recording with Trellis 1.7.4.27).