### PR TITLE
fixed bug in openNEV.m on line 445 when using Matlab 2025b, issue #79

### DIFF
--- a/NPMK/openNEV.m
+++ b/NPMK/openNEV.m
@@ -442,7 +442,7 @@ NEV.MetaTags.TimeRes      = double(typecast(BasicHeader(21:24), 'uint32'));
 NEV.MetaTags.SampleRes    = typecast(BasicHeader(25:28), 'uint32');
 t                         = double(typecast(BasicHeader(29:44), 'uint16'));
 tempApp                   = BasicHeader(45:76)';
-tempApp(find(tempApp == 0):end) = [];
+tempApp(find(tempApp == 0, 1, 'first'):end) = [];
 NEV.MetaTags.Application  = char(tempApp); clear tempApp;
 NEV.MetaTags.Comment      = char(BasicHeader(77:332)');
 [NEV.MetaTags.FilePath, NEV.MetaTags.Filename, NEV.MetaTags.FileExt] = fileparts(fileFullPath);


### PR DESCRIPTION
Hello :)
I reported a bug (issue #79 in your git repo) regarding a bug in openNEV when using Maltab2025b. This required a very small fix in line 445, which I implemented:
find(tempApp ==0) --> find(temApp ==0, 1, 'first'). This makes sure that both the argument around the : operator are real scalars and not arrays. See details in the bug report. 